### PR TITLE
Close issue #9: Edit transaction feature added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ token.json
 credentials.json
 .vscode
 budget.egg-info
+venv/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ https://docs.google.com/spreadsheets/d/<SPREADSHEET_ID>/edit#gid=<SHEET_ID>
 
  * For `expense` and `income` commands, today's date will be assigned and this month's spreadsheet will be used unless a custom date is specified explicitly as the first argument of transaction parameters.
 
+ * For `edit`, original date of the transaction is assigned and this month's spreadsheet will be used unless date is specified explicitly.
+
 ### Transaction Entry
 ``` sh
 # append expense for custom date
@@ -49,6 +51,12 @@ budget income "Aug 2, 3000, Salary, Paycheck"
 
 # append income for today
 budget income "3000, Salary, Paycheck"
+
+# edit line 4 of income for this month (see line number in `budget log`)
+budget edit income 4 "65, Tax Return, Other"
+
+# edit line 5 of expense for September (see line number in `budget log`)
+budget edit expense 5 "Sep 17, Mobile Plan, Communication"
 ```
 
 ### Summary

--- a/budget/__main__.py
+++ b/budget/__main__.py
@@ -186,16 +186,16 @@ def getMonthlySheetId(date, sheetIds):
 # reads program arguments
 def readArgs():
     if sys.argv[1] not in COMMAND_SET:
-        raise UserWarning("Invalid command. Valid commands are:\n{0}".format(COMMAND_SET))
+        raise UserWarning("Invalid command type: Valid command types are:\n{0}".format(COMMAND_SET))
     elif sys.argv[1] in ('income', 'expense'):
         if len(sys.argv) != 3:
             raise UserWarning("Missing transaction parameters for '{0}' command.".format(sys.argv[1]))
         return sys.argv[1], sys.argv[2]
     elif sys.argv[1] == "edit":
         if sys.argv[2] not in ('income', 'expense'):
-            raise UserWarning("Invalid command. Edit command has to have 'expense' or 'income' as 3rd argument.")
+            raise UserWarning("Invalid command: Edit command has to have 'expense' or 'income' as 3rd argument.")
         if len(sys.argv) != 5:
-            raise UserWarning("Too many or too few argument provided. Exactly 5 arguments are required for edit command.")
+            raise UserWarning("Invalid command: Edit command requires exactly 5 arguments.")
         return sys.argv[1], (sys.argv[2], sys.argv[3], sys.argv[4])
     else:
         if len(sys.argv) == 3:

--- a/budget/__main__.py
+++ b/budget/__main__.py
@@ -83,13 +83,11 @@ def validate(transaction, categories):
         raise UserWarning(message)
 
 # parses transaction fields & inserts a date field (today) if not specified
-def parseTransaction(params, editMode=False):
+def parseTransaction(params):
     transaction = [e.strip() for e in params.split(',')]
     noExplicitDate = len(transaction) is NUM_TRANSACTION_FIELDS - 1
     if noExplicitDate:
         transaction.insert(0, datetime.now())
-        if editMode is False:
-            print("Only 3 fields were specified. Assigning today to date field.")
     if len(transaction) != NUM_TRANSACTION_FIELDS:
         raise UserWarning("Invalid number of fields in transaction.")
     try:
@@ -211,7 +209,9 @@ def main():
         command, param = readArgs()
         service = getSheetService()
         if command in ('expense', 'income'):
-            transaction, _ = parseTransaction(param)
+            transaction, noExplicitDate = parseTransaction(param)
+            if noExplicitDate is True:
+                print("Only 3 fields were specified. Assigning today to date field.")
             monthlySheetId = getMonthlySheetId(transaction[0], sheetIds)
             summary = readSummaryPage(service, monthlySheetId)
             categories = summary.categories.expense if command == 'expense' else summary.categories.income
@@ -222,7 +222,7 @@ def main():
         if command == "edit":
             subcommand = param[0]
             lineIndex = int(param[1])
-            transaction, noExplicitDate = parseTransaction(param[2], editMode=True)
+            transaction, noExplicitDate = parseTransaction(param[2])
             monthlySheetId = getMonthlySheetId(transaction[0], sheetIds)
             transactions = readTransactions(service, monthlySheetId, subcommand)
             validateLineIndex(lineIndex, transactions)

--- a/budget/__main__.py
+++ b/budget/__main__.py
@@ -61,10 +61,10 @@ def insertTransaction(transaction, service, command, monthlySheetId, title):
     print('Transaction inserted in {0} budget:\n{1}'.format(title, transaction))
 
 # edits an existing income/expense transaction in monthly budget spreadsheet
-def editTransaction(lineIndex, newTransaction, service, subcommand, monthlySheetId, title):
+def editTransaction(lineIndex, newTransaction, service, command, monthlySheetId, title):
     rowIdx = FIRST_TRANSACTION_ROW + lineIndex - 1
-    startCol = "B" if subcommand == 'expense' else "G"
-    endCol = "E" if subcommand == 'expense' else "J"
+    startCol = "B" if command == 'expense' else "G"
+    endCol = "E" if command == 'expense' else "J"
     rangeName = "Transactions!" + startCol + str(rowIdx) + ":" + endCol + str(rowIdx)
     writeCells(service, monthlySheetId, rangeName, [newTransaction])
     print('Transaction edited in {0} budget:\n{1}'.format(title, newTransaction))
@@ -84,13 +84,12 @@ def validate(transaction, categories):
 
 # parses transaction fields & inserts a date field (today) if not specified
 def parseTransaction(params, editMode=False):
-    dateAdded = False
     transaction = [e.strip() for e in params.split(',')]
-    if len(transaction) is NUM_TRANSACTION_FIELDS - 1:
+    noExplicitDate = len(transaction) is NUM_TRANSACTION_FIELDS - 1
+    if noExplicitDate:
+        transaction.insert(0, datetime.now())
         if editMode is False:
             print("Only 3 fields were specified. Assigning today to date field.")
-        transaction.insert(0, datetime.now())
-        dateAdded = True
     if len(transaction) != NUM_TRANSACTION_FIELDS:
         raise UserWarning("Invalid number of fields in transaction.")
     try:
@@ -98,7 +97,7 @@ def parseTransaction(params, editMode=False):
             raise ValueError()
     except ValueError:
             raise UserWarning("Invalid transaction amount: {0}".format(transaction[1]))
-    return transaction, dateAdded
+    return transaction, noExplicitDate
 
 # synchronizes annual budget with monthly budget data
 def sync(service, ssheetId, sheetName, title, categories):

--- a/config.json
+++ b/config.json
@@ -1,15 +1,15 @@
 {
-    "jan": "12hCXvyNoDZ0jXdOHRJZ3o_O-9Q85oKN3RrNdVZfwJ84",
-    "feb": "1GQQWbGfNW0dA9FhQSvTvKVTJDQ2xK_oaw0iS6JCPcHg",
-    "mar": "1TtAiLSABaSza3LNwtPBXTuSxwgAZuYUNAP_ialaQX_g",
-    "apr": "1wlbCo4V4XHYXAWQbQalJeYRVvIyENaLT9DXtu8lu69M",
-    "may": "1IJFOtz8GM8Z1Bq4HHNkWv03l06L3Ms8YdOIBTApE1ew",
-    "jun": "1Et0ES6eVkR2rG6wMpkxtBu5Zpe7TDZZP4L1kDlAv6m8",
-    "jul": "19EBYUVlgM_18eKjdJYPufv8jrrxHDo2mwImMSkTD-mc",
-    "aug": "100_2wY2kNtfYjKVJqTB5e4Hy3kwspU1jePEhnh6__50",
-    "sep": "18ugh4qGa-qm2TfdflEOvAxpopDZC0LBjScgOn548eGs",
-    "oct": "1S1JuEX7XDjhFixJ1sVtdwUU6hk6sAWy4-CzqcSd5bps",
-    "nov": "1zfyLSUiHuxQrrLgHaZclRbLZpctDubzAhxe_GvK0GwA",
-    "dec": "1Ni0KQ_BUmROKlGyV9D5kMgJoHdzb-8doyKwP-_Ya7Io",
-    "annual": "1mAal048jY0NkUV9ov-7jFITkFuKbgbNaWP70s-vTvXQ"
+    "jan": "17mGHOKSp1vmlisvxBTIVWJPpIUSDIQkrU1sWSjQxSXc",
+    "feb": "1JR_KZRLCnlSwsTUQFDpWdAb_Ui1Dalq4EeR38ixRByw",
+    "mar": "1FLd7ZrDY7cyYDK0nIa-5uAXCIBc65YX202cinuSRj6o",
+    "apr": "1NPysr2D_E__au8cgWoNdlRZzzOoFiQQVr3iIY98quag",
+    "may": "13Jfy50oC92shuNUtfRrkQ0VHah_RA6T29Jm7iN9GiRc",
+    "jun": "1X6v-VShtYj1DwPS9YiBvYAVkk-PvQmCNGIpeLLzBgUo",
+    "jul": "1J4b9GndCw2uuSVU9VJVAhhkmvz1e_hH8p2c4U31u0ZI-mc",
+    "aug": "1kzWBr07BeJobUY6ATIQAnuWttwPMFuv2Mz2fj1JqDE8",
+    "sep": "1yfkmo_8KDmjwhAuStiVoXCoPUsPcE9-IwYsv-u8d9gY",
+    "oct": "1Qx4jx6wkxJzoBCLaYLkckFtG9HcO4GGkvv7HrBTVRis",
+    "nov": "1CAuN5yiRXg-NqEfKASjHdjxRtKvhxlew8HNclhi9tjA",
+    "dec": "1Q4RZI22DBNAiHGWfpq154zzkimjBUKazoEXtJtzFUHY",
+    "annual": "1L0LgzMYBxHfidCR-RFdQxLI8wp08fhNsdiJ3ohwk1so"
 }

--- a/config.json
+++ b/config.json
@@ -1,15 +1,15 @@
 {
-    "jan": "17mGHOKSp1vmlisvxBTIVWJPpIUSDIQkrU1sWSjQxSXc",
-    "feb": "1JR_KZRLCnlSwsTUQFDpWdAb_Ui1Dalq4EeR38ixRByw",
-    "mar": "1FLd7ZrDY7cyYDK0nIa-5uAXCIBc65YX202cinuSRj6o",
-    "apr": "1NPysr2D_E__au8cgWoNdlRZzzOoFiQQVr3iIY98quag",
-    "may": "13Jfy50oC92shuNUtfRrkQ0VHah_RA6T29Jm7iN9GiRc",
-    "jun": "1X6v-VShtYj1DwPS9YiBvYAVkk-PvQmCNGIpeLLzBgUo",
-    "jul": "1J4b9GndCw2uuSVU9VJVAhhkmvz1e_hH8p2c4U31u0ZI-mc",
-    "aug": "1kzWBr07BeJobUY6ATIQAnuWttwPMFuv2Mz2fj1JqDE8",
-    "sep": "1yfkmo_8KDmjwhAuStiVoXCoPUsPcE9-IwYsv-u8d9gY",
-    "oct": "1Qx4jx6wkxJzoBCLaYLkckFtG9HcO4GGkvv7HrBTVRis",
-    "nov": "1CAuN5yiRXg-NqEfKASjHdjxRtKvhxlew8HNclhi9tjA",
-    "dec": "1Q4RZI22DBNAiHGWfpq154zzkimjBUKazoEXtJtzFUHY",
-    "annual": "1L0LgzMYBxHfidCR-RFdQxLI8wp08fhNsdiJ3ohwk1so"
+    "jan": "12hCXvyNoDZ0jXdOHRJZ3o_O-9Q85oKN3RrNdVZfwJ84",
+    "feb": "1GQQWbGfNW0dA9FhQSvTvKVTJDQ2xK_oaw0iS6JCPcHg",
+    "mar": "1TtAiLSABaSza3LNwtPBXTuSxwgAZuYUNAP_ialaQX_g",
+    "apr": "1wlbCo4V4XHYXAWQbQalJeYRVvIyENaLT9DXtu8lu69M",
+    "may": "1IJFOtz8GM8Z1Bq4HHNkWv03l06L3Ms8YdOIBTApE1ew",
+    "jun": "1Et0ES6eVkR2rG6wMpkxtBu5Zpe7TDZZP4L1kDlAv6m8",
+    "jul": "19EBYUVlgM_18eKjdJYPufv8jrrxHDo2mwImMSkTD-mc",
+    "aug": "100_2wY2kNtfYjKVJqTB5e4Hy3kwspU1jePEhnh6__50",
+    "sep": "18ugh4qGa-qm2TfdflEOvAxpopDZC0LBjScgOn548eGs",
+    "oct": "1S1JuEX7XDjhFixJ1sVtdwUU6hk6sAWy4-CzqcSd5bps",
+    "nov": "1zfyLSUiHuxQrrLgHaZclRbLZpctDubzAhxe_GvK0GwA",
+    "dec": "1Ni0KQ_BUmROKlGyV9D5kMgJoHdzb-8doyKwP-_Ya7Io",
+    "annual": "1mAal048jY0NkUV9ov-7jFITkFuKbgbNaWP70s-vTvXQ"
 }


### PR DESCRIPTION
This pull request closes issue #9.

The syntax for the new command is as following and documented in README.md
```
budget edit [income | expense] [line_index] [new_transsaction]
```
When a date is not specified in `new_transasction`, the original date is used. When a date is specified, the new date is used. The monthly spreadsheet's ID will be identified based on the month in the transaction date.

The `budget log` command now displays line index to be used in editing transaction:
```
Oct Expense Log
===============================================================================      
   1   08/09/2000    $1,500.00    Rent                                Home
   2   13/10/2019       $35.00    Groceries                           Home
   3   13/10/2019        $5.00    Pizza                               Food
   4   13/10/2019        $5.00    Pizza                               Food

Oct Income Log
===============================================================================      
   1   08/09/2000    $2,000.00    Paycheck                            Paycheck       
   2   13/10/2019       $75.00    Tax Return                          Other
   3   13/10/2019      $100.00    Scholarship                         Bonus
   4   13/10/2019      $100.00    Scholarship                         Bonus
   5   13/10/2019       $75.00    Tax Return                          Other
```